### PR TITLE
x86 Zeroize Support feature. Pending aarch64 testing

### DIFF
--- a/utils-simd/ppv-lite86/CHANGELOG.md
+++ b/utils-simd/ppv-lite86/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-21
+
+### Added
+- Introduced `zeroize_support` feature for securely zeroing out sensitive data in memory.
+  - Implemented `Zeroize` trait for relevant types in the library to enable secure zeroing when the feature is enabled.
+  - This feature can be enabled via `ppv_lite86 = { version = "0.3", features = ["zeroize_support"] }` in your `Cargo.toml`.
+
 ## [0.2.16]
 ### Added
 - add [u64; 4] conversion for generic vec256, to support BLAKE on non-x86.

--- a/utils-simd/ppv-lite86/Cargo.toml
+++ b/utils-simd/ppv-lite86/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.3.0"
 authors = ["The CryptoCorrosion Contributors"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -10,6 +10,7 @@ keywords = ["crypto", "simd", "x86"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
+zeroize = { version = "1.6.0", optional = true }
 
 [badges]
 travis-ci = { repository = "cryptocorrosion/cryptocorrosion" }
@@ -19,3 +20,4 @@ default = ["std"]
 std = []
 simd = [] # deprecated
 no_simd = []
+zeroize_support = ["zeroize"]

--- a/utils-simd/ppv-lite86/src/generic.rs
+++ b/utils-simd/ppv-lite86/src/generic.rs
@@ -4,12 +4,19 @@ use crate::soft::{x2, x4};
 use crate::types::*;
 use core::ops::*;
 
+#[cfg(feature = "zeroize_support")] use zeroize::Zeroize;
+
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize),
+)]
 pub union vec128_storage {
     d: [u32; 4],
     q: [u64; 2],
 }
+#[cfg(feature = "zeroize_support")]
 impl From<[u32; 4]> for vec128_storage {
     #[inline(always)]
     fn from(d: [u32; 4]) -> Self {
@@ -48,6 +55,10 @@ impl PartialEq<vec128_storage> for vec128_storage {
     }
 }
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize)
+)]
 pub struct vec256_storage {
     v128: [vec128_storage; 2],
 }
@@ -78,6 +89,10 @@ impl From<[u64; 4]> for vec256_storage {
     }
 }
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "zeroize_support",
+    derive(Zeroize)
+)]
 pub struct vec512_storage {
     v128: [vec128_storage; 4],
 }
@@ -861,5 +876,11 @@ mod test {
 
         let y = m.vec(ys);
         assert_eq!(x, y);
+    }
+
+    #[test]
+    #[cfg(feature = "zeroize")]
+    fn test_zeroize_vec128_storage_generic() {
+        
     }
 }


### PR DESCRIPTION
Added some Zeroize support. It is mainly for the vec128_storage so that rand_chacha::ChaCha20Rng is able to be zeroized.